### PR TITLE
Making plugin usable with typescript

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -7,6 +7,7 @@ import cached from 'gulp-cached';
 import istanbul from 'gulp-istanbul'
 import coveralls from 'gulp-coveralls';
 import remapIstanbul from 'remap-istanbul/lib/gulpRemapIstanbul';
+import merge from 'merge-stream';
 import del from 'del';
 import path from 'path';
 
@@ -34,9 +35,11 @@ gulp.task('tslint', () => {
 const tsproject = tsc.createProject('tsconfig.json');
 
 gulp.task('assemble', ['clean', 'tslint'], () => {
-    return gulp.src(sourceFiles)
+    const source = gulp.src(sourceFiles)
         .pipe(sourcemaps.init())
-        .pipe(tsproject()).js
+        .pipe(tsproject())
+
+    return merge(source.js, source.dts)
         .pipe(sourcemaps.write('./', {
             includeContent: false,
             sourceRoot: '../src'

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "The plugin for Gulp which allows to pack ArmA pbo files from sources.",
     "repository": "https://github.com/winseros/gulp-armapbo-plugin",
     "main": "dist/main.js",
+    "types": "dist/main.d.ts",
     "scripts": {
         "test": "./node_modules/.bin/gulp test:run",
         "cover": "./node_modules/.bin/gulp cover:report",
@@ -47,6 +48,7 @@
         "gulp-sourcemaps": "^2.6.1",
         "gulp-tslint": "^8.1.2",
         "gulp-typescript": "^3.2.3",
+        "merge-stream": "^1.0.1",
         "mocha": "^4.0.1",
         "remap-istanbul": "^0.9.5",
         "sinon": "^4.1.3",
@@ -64,6 +66,7 @@
     "files": [
         "dist/**/*.js",
         "dist/**/*.js.map",
+        "dist/**/*.d.ts",
         "!**/test/"
     ]
 }

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ const pbo = require('gulp-armapbo');
 
 gulp.task('pack', () => {
     return gulp.src('pbo-contents/**/*')
-        .pipe(pbo({
+        .pipe(pbo.pack({
             fileName: 'my-file.pbo',
             extensions: [{
                 name: 'author',
@@ -35,8 +35,34 @@ gulp.task('pack', () => {
 });
 ```
 
+## Usage with TypeScript
+```
+import * as gulp from 'gulp';
+import {pack, StreamOptions} from 'gulp-armapbo';
+
+gulp.task('pack', () => {
+    return gulp.src('pbo-contents/**/*')
+        .pipe(pack({
+            fileName: 'my-file.pbo',
+            extensions: [{
+                name: 'author',
+                value: 'Author Name'
+            }, {
+                name: 'mission',
+                value: 'Mission Name'
+            }],
+            compress: [
+                '**/*.sqf',
+                'mission.sqm',
+                'description.ext'
+            ]
+        } as StreamOptions))
+        .pipe(gulp.dest('pbo-packed/'));
+});
+```
+
 ## Plugin API
-pbo([options])
+pbo.pack([options])
 
 ### Options
 Required: `no`

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { PboTransformStream } from './core/pboTransformStream';
 import { StreamOptions } from './core/streamOptions';
+import { Transform } from 'stream';
 
-export = (options?: StreamOptions): PboTransformStream => {
+const pack = (options?: StreamOptions): Transform => {
     return new PboTransformStream(options);
 };
+
+export {pack, StreamOptions};


### PR DESCRIPTION
The PR makes the plugin compatible with gulpfile`s written in TypeScript. To achieve that I had to change signature of plugin export. Apparently if the PR is accepted, that would lead to the major version increment.